### PR TITLE
【仕様変更】 引用(ノートリンク)の管理をDB保存に変更

### DIFF
--- a/Synapsen_Ersteller/Synapsen_Ersteller_main.py
+++ b/Synapsen_Ersteller/Synapsen_Ersteller_main.py
@@ -1,26 +1,37 @@
+# === 1. 標準ライブラリ ===
 import os
+import sys
+from pathlib import Path
 import tkinter
 import csv
-import sys
 import json
 from textwrap import dedent
-import db_recovery_tool
-from tkinter import messagebox
-from pathlib import Path
-from pypdf import PdfReader, PdfWriter, Transformation
-import customtkinter as ctk
 import subprocess
 import shutil
 import tempfile
 import configparser
 import sqlite3
-import pandas as pd
-
 import logging
-import PDFMargeHelper as Helper
-import pdf_processor as Process
-import latex_generator as Generator
-import gui_dialogs as Dialogs
+
+# === 2. プロジェクトルートをパスに追加 ===
+current_dir = Path(__file__).parent
+root_dir = current_dir.parent
+if str(root_dir) not in sys.path:
+    sys.path.append(str(root_dir))
+
+# === 3. プロジェクト内モジュールとサードパーティ ===
+import db_recovery_tool               # noqa: E402
+from tkinter import messagebox        # noqa: E402 (tkinterグループ)
+import customtkinter as ctk           # noqa: E402
+import pandas as pd                   # noqa: E402
+import PDFMargeHelper as Helper       # noqa: E402
+import pdf_processor as Process       # noqa: E402
+import latex_generator as Generator   # noqa: E402
+import gui_dialogs as Dialogs         # noqa: E402
+from pypdf import PdfReader, PdfWriter, Transformation  # noqa: E402
+from Synapsen_Nexus import utils as NexusUtils          # noqa: E402
+from logging_setup import setup_logging                 # noqa: E402
+
 
 # ==============================================================================
 # ロギング設定の初期化
@@ -32,7 +43,6 @@ if str(root_dir) not in sys.path:
     sys.path.append(str(root_dir))
 
 try:
-    from logging_setup import setup_logging
     # アプリ名を指定して初期化
     setup_logging("Synapsen_Normalisierer")
     logger = logging.getLogger("Normalisierer")  # このファイル用のロガー取得
@@ -396,10 +406,7 @@ class Synapsen_Ersteller(ctk.CTk):
         if not notes_to_append:
             return
 
-        # 1. 追記するノートをDataFrameに変換
         df_new_notes = pd.DataFrame(notes_to_append)
-
-        # 'key' (ユニークID) がないノートは追記しない (以前の会話で実装した仕様)
         df_new_notes = df_new_notes[
             df_new_notes['key'].notna() & (df_new_notes['key'] != '')
         ]
@@ -409,8 +416,16 @@ class Synapsen_Ersteller(ctk.CTk):
 
         # タグリストを ';' 区切りの文字列に変換
         if 'tags' in df_new_notes.columns:
-            df_new_notes['tags'] = df_new_notes['tags'].apply(
-                lambda tags: ";".join(sorted(tags)) if isinstance(tags, list) else ''
+
+            # タグをソートし、';'区切りの文字列に変換する関数を定義
+            def format_tags_for_db(tags):
+                if isinstance(tags, list):
+                    return ";".join(sorted(tags))
+                return ''  # リストでない場合は空文字を返す
+
+            # apply に定義した関数を渡す
+            df_new_notes['tags'] = (
+                df_new_notes['tags'].apply(format_tags_for_db)
             )
 
         conn = sqlite3.connect(self.default_db_path)
@@ -469,6 +484,21 @@ class Synapsen_Ersteller(ctk.CTk):
             END;
         """)
             cursor.executescript(trigger_sql)
+
+            # --- リンクテーブル作成 ▼▼▼ ---
+            cursor.execute("""
+            CREATE TABLE IF NOT EXISTS note_links (
+                source_key TEXT NOT NULL,
+                target_key TEXT NOT NULL,
+                PRIMARY KEY (source_key, target_key)
+            )
+            """)
+
+            cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_target_key
+                ON note_links (target_key)
+            """)
+
             conn.commit()
 
             # 2. 既存のキーをDBから取得
@@ -511,11 +541,28 @@ class Synapsen_Ersteller(ctk.CTk):
                 if_exists='append',
                 index=False
             )
+
+            # 5. 追記したノートのリンク情報を解析して note_links に書き込む
+            #    (Nexusのutils.pyにあるヘルパーを流用)
+            logger.info(f"{len(df_to_append)} 件の新規ノートのリンクを解析・登録します...")
+
+            for _, row in df_to_append.iterrows():
+                source_key = row.get("key")
+                memo_text = row.get("memo", "")
+                if source_key and memo_text:
+                    # (utils._update_note_links は DELETE & INSERT を行う)
+                    NexusUtils._update_note_links(
+                        cursor, source_key, memo_text
+                    )
+
+            conn.commit()  # リンクテーブルの変更をコミット
+
             logger.info(
-                f"{len(df_final_append)} 件の新規ノートを " +
+                f"{len(df_to_append)} 件の新規ノートを " +
                 f"{master_db_path.name} に追記しました。")
 
         except Exception as e:
+            conn.rollback()
             raise Exception(f"マスターDBへの追記に失敗しました: {e}")
         finally:
             conn.close()

--- a/Synapsen_Ersteller/db_recovery_tool.py
+++ b/Synapsen_Ersteller/db_recovery_tool.py
@@ -1,15 +1,26 @@
-import customtkinter as ctk
-from tkinter import filedialog, messagebox
-import pandas as pd
-import sqlite3
-import json
+# === 1. 標準ライブラリ ===
+import sys
 from pathlib import Path
-from pypdf import PdfReader
-import fitz  # PyMuPDF (テキスト抽出用)
+import json
 import unicodedata
 from textwrap import dedent
-
 import logging
+
+# === 2. プロジェクトルートをパスに追加 (ここからE402の原因) ===
+current_dir = Path(__file__).parent
+root_dir = current_dir.parent
+if str(root_dir) not in sys.path:
+    sys.path.append(str(root_dir))
+
+# === 3. プロジェクト内モジュールとサードパーティ (E402を抑制) ===
+import customtkinter as ctk                     # noqa: E402
+from tkinter import filedialog, messagebox      # noqa: E402
+import pandas as pd                             # noqa: E402
+import sqlite3                                  # noqa: E402
+from pypdf import PdfReader                     # noqa: E402
+import fitz                                     # noqa: E402
+from Synapsen_Nexus import utils as NexusUtils  # noqa: E402
+
 logger = logging.getLogger(__name__)
 
 
@@ -173,7 +184,7 @@ class DBRecoveryWindow(ctk.CTkToplevel):
         if not self.extracted_data:
             return
 
-        # 確認ダイアログ (省略なしで既存通り)
+        # 確認ダイアログ
         ans = messagebox.askyesno(
             "実行確認",
             f"{len(self.extracted_data)} 件のデータを以下のDBに復元します。\n\n"
@@ -193,20 +204,22 @@ class DBRecoveryWindow(ctk.CTkToplevel):
 
         # 統合PDFから本文テキスト(full_text)を再抽出するためのPDFドキュメントを開く
         doc = None
+        conn = None  # 1. conn を None で初期化
+
         try:
             doc = fitz.open(pdf_path)
         except Exception as e:
             self.log(f"[エラー] テキスト抽出のためにPDFを開けませんでした: {e}")
-            return
+            return  # doc が None のまま finally に進み、安全に終了
 
         try:
             # DataFrameに変換
             df = pd.DataFrame(self.extracted_data)
 
-            # 1. 統合PDFファイル名の上書き
+            # 統合PDFファイル名の上書き
             df['merged_pdf_filename'] = current_pdf_name
 
-            # 2. タグリストを文字列(;)に戻す
+            # タグリストを文字列(;)に戻す
             if 'tags' in df.columns:
                 df['tags'] = df['tags'].apply(
                     lambda x: ";".join(sorted(x)) if isinstance(x, list) else x
@@ -265,10 +278,13 @@ class DBRecoveryWindow(ctk.CTkToplevel):
                     return ""
 
             # 各行に対してテキスト抽出を実行
-            # (tqdmなどが使えないのでGUIが固まらないよう簡易的に処理)
             df['full_text'] = df.apply(extract_text_from_range, axis=1)
 
-            conn = sqlite3.connect(db_path)
+            # 復元データ (JSON) が 'memo' を持っていることを確認
+            if 'memo' not in df.columns:
+                df['memo'] = ""  # 万が一ない場合は空文字で埋める
+
+            conn = sqlite3.connect(db_path)  # 2. conn に代入
             cursor = conn.cursor()
 
             # 1. 'notes' テーブル
@@ -333,6 +349,18 @@ class DBRecoveryWindow(ctk.CTkToplevel):
             END;
         """)
             cursor.executescript(trigger_sql)
+            cursor.execute("""
+            CREATE TABLE IF NOT EXISTS note_links (
+                source_key TEXT NOT NULL,
+                target_key TEXT NOT NULL,
+                PRIMARY KEY (source_key, target_key)
+            )
+            """)
+            cursor.execute("""
+            CREATE INDEX IF NOT EXISTS idx_target_key
+                ON note_links (target_key)
+            """)
+
             conn.commit()
 
             # 重複チェックとインサート
@@ -351,6 +379,18 @@ class DBRecoveryWindow(ctk.CTkToplevel):
             if insert_count > 0:
                 df_to_insert.to_sql(
                     'notes', conn, if_exists='append', index=False)
+
+                # リンクテーブル書き込み
+                logger.info(f"{len(df_to_insert)} 件の復元ノートのリンクを解析・登録します...")
+                for _, row in df_to_insert.iterrows():
+                    source_key = row.get("key")
+                    memo_text = row.get("memo", "")  # 復元データ(JSON)のmemoを使用
+                    if source_key and memo_text:
+                        NexusUtils._update_note_links(
+                            cursor, source_key, memo_text
+                        )
+
+                conn.commit()  # リンクテーブルの変更をコミット
                 self.log(f"[完了] {insert_count} 件を追記しました。")
             else:
                 self.log("[完了] 新規データはありませんでした (すべて重複)。")
@@ -358,15 +398,19 @@ class DBRecoveryWindow(ctk.CTkToplevel):
             if skipped_count > 0:
                 self.log(f"(重複のためスキップ: {skipped_count} 件)")
 
-            conn.close()
-            doc.close()  # ドキュメントを閉じる
-
             messagebox.showinfo(
                 "完了", "データベースの復元が完了しました。\n(本文テキストもunicode正規化されました)")
             self.destroy()
 
         except Exception as e:
-            if doc:
-                doc.close()
+            if conn:
+                conn.rollback()
             self.log(f"[エラー] DB書き込み中にエラー: {e}")
             messagebox.showerror("エラー", f"復元に失敗しました:\n{e}")
+
+        finally:
+            # doc と conn を両方ともここで閉じる
+            if doc:
+                doc.close()
+            if conn:
+                conn.close()

--- a/Synapsen_Nexus/Synapsen_Nexus_main.py
+++ b/Synapsen_Nexus/Synapsen_Nexus_main.py
@@ -14,7 +14,7 @@ import logging
 
 from utils import (
     load_app_config, load_sql_data_file, open_pdf_viewer,
-    build_memo_display, build_references_display, find_backlinks_df,
+    build_memo_display, build_references_display,
     update_note_in_db, delete_note_from_db,
     get_pdf_page_image
 )
@@ -862,6 +862,7 @@ class Synapsen_Nexus(ctk.CTk):
                 Noneの場合は詳細ペインをクリアする。
         """
         try:
+            # --- 1. 読み取り専用接続 (db_conn) のクローズ/再生成 ---
             if self.db_conn:
                 self.db_conn.close()
                 self.db_conn = None
@@ -869,14 +870,43 @@ class Synapsen_Nexus(ctk.CTk):
             self.df = load_sql_data_file(filepath)  # utils (full_textなし)
             self.loaded_db_path = filepath
 
-            # 読み取り専用のDB接続を保持
+            # 読み取り専用のDB接続を保持 (メインのUI用)
             self.db_conn = sqlite3.connect(
                 f"file:{filepath}?mode=ro", uri=True)
 
-            # データを読み込んだらタグリストを更新
-            self.refresh_unique_tags()
+            # --- 2. テーブル構造の確認 (書き込み接続) ---
+            # アプリ起動時/DB読込時に note_links テーブルが存在するか確認し、なければ作成
+            conn_write = None
+            try:
+                conn_write = sqlite3.connect(filepath)  # 書き込みモードで接続
+                cursor = conn_write.cursor()
 
-            # UIをリセット・更新
+                # リンクテーブルの作成
+                cursor.execute("""
+                CREATE TABLE IF NOT EXISTS note_links (
+                    source_key TEXT NOT NULL,
+                    target_key TEXT NOT NULL,
+                    PRIMARY KEY (source_key, target_key)
+                )
+                """)
+                # 引用元検索(target_key)を高速化するインデックス
+                cursor.execute("""
+                CREATE INDEX IF NOT EXISTS idx_target_key
+                    ON note_links (target_key)
+                """)
+                conn_write.commit()
+                logger.info("'note_links' テーブルの存在を確認・作成しました。")
+
+            except Exception as e_tbl:
+                logger.error(f"'note_links' テーブルの作成に失敗: {e_tbl}")
+                if conn_write:
+                    conn_write.rollback()
+            finally:
+                if conn_write:
+                    conn_write.close()
+
+            # --- 3. UIリセット ---
+            self.refresh_unique_tags()
             self.perform_search()
 
             # 変更したノートを再表示するロジック
@@ -1465,7 +1495,6 @@ class Synapsen_Nexus(ctk.CTk):
     def show_details(self, row_data):
         """
         選択されたノートの詳細を右ペインに表示する。
-        (FTS5対応版: メタデータはrow_dataから、memoはDBから取得)
 
         Args:
             row_data (pd.Series): 表示するノートの行データ。
@@ -1496,9 +1525,7 @@ class Synapsen_Nexus(ctk.CTk):
         # 既存のプレビューラベルを破棄
         if hasattr(self, 'pdf_preview_label'):
             self.pdf_preview_label.destroy()
-
-        max_preview_width = 225  # プレビュー表示の最大幅
-
+        max_preview_width = 225
         pil_image = get_pdf_page_image(
             row_data,
             self.loaded_db_path,
@@ -1529,7 +1556,7 @@ class Synapsen_Nexus(ctk.CTk):
                 image=None,
                 text="プレビューの読み込みに失敗しました",
                 fg_color="gray20",
-                text_color="#D9534F"  # 赤色
+                text_color="#D9534F"
             )
 
         # 新しく作成したラベルをグリッドに配置
@@ -1537,16 +1564,18 @@ class Synapsen_Nexus(ctk.CTk):
             row=4, column=0, columnspan=2, padx=10, pady=10, sticky="nsew"
         )
 
-        # --- メモと引用元の表示 ---
+        # --- メモと引用元の取得 ---
+
         current_key = row.get('key', '')
 
-        # 【FTS5対応】 memo と 引用元検索(self.dfのmemo) のためにDBから最新データを取得
         memo_text = ""
         backlinks_df = pd.DataFrame()  # 空で初期化
 
         try:
-            # 1. このノートの 'memo' を取得 (DBから)
+            # (db_conn は読み取り専用接続)
             cursor = self.db_conn.cursor()
+
+            # 1. このノートの 'memo' を取得
             cursor.execute(
                 "SELECT memo FROM notes WHERE key = ?", (current_key,)
             )
@@ -1554,26 +1583,30 @@ class Synapsen_Nexus(ctk.CTk):
             if memo_data:
                 memo_text = str(memo_data[0])
 
-            # 2. 引用元 (Backlinks) を self.df の 'memo' (メモリ上) で検索
+            # 2. 引用元 (Backlinks) を 'note_links' テーブルから取得
 
-            # FTS5 で 'memo' 列を検索
-            fts_query_term = f'"{current_key}"'  # FTSは [[ や : を無視する可能性がある
-            sql = "SELECT rowid FROM notes_fts WHERE memo MATCH ?"
-            cursor.execute(sql, (fts_query_term,))
+            # リンクテーブルを検索
+            sql = "SELECT source_key FROM note_links WHERE target_key = ?"
+
+            cursor.execute(sql, (current_key,))
 
             matching_keys = {row[0] for row in cursor.fetchall()}
 
-            # FTSの結果をメモリ上の self.df でフィルタリング
             if matching_keys:
+                logger.debug(
+                    f"[show_details] リンクテーブル検索ヒット: {len(matching_keys)} 件 "
+                    f"(Key: {current_key})"
+                )
                 backlinks_df = self.df[self.df['key'].isin(matching_keys)]
             else:
-                backlinks_df = pd.DataFrame()
+                logger.debug(
+                    f"[show_details] リンクテーブル検索 0件 "
+                    f"(Key: {current_key})"
+                )
 
         except Exception as e:
             logger.error(f"詳細表示のためのDBアクセスエラー: {e}", exc_info=True)
-            # エラー時は self.df の古い 'memo' を使う (空文字になる)
-            memo_text = str(row.get('memo', ''))
-            backlinks_df = find_backlinks_df(self.df, current_key)  # 空のDFが返る
+            pass  # 失敗時は空のまま
 
         # メモ表示（リンク構築）
         for widget in self.memo_display_frame.winfo_children():
@@ -1581,16 +1614,15 @@ class Synapsen_Nexus(ctk.CTk):
         frame_width = 450
         build_memo_display(
             self.memo_display_frame,
-            memo_text,  # DBから取得した最新のメモ
-            self.df,    # リンク先のタイトル検索用 (metaデータのみ)
+            memo_text,
+            self.df,
             self.open_preview_window,
             frame_width
         )
-
         # 引用元UIを構築
         build_references_display(
             self.references_display_frame,
-            backlinks_df,  # DBからFTS検索した引用元
+            backlinks_df,
             self.open_preview_window,
             self.key_icons,
             self.key_colors
@@ -1676,7 +1708,8 @@ class Synapsen_Nexus(ctk.CTk):
                 self.key_colors,
                 self.loaded_db_path,
                 self.pdf_root_folder,
-                output_path=output_path
+                output_path=output_path,
+                db_conn=self.db_conn
             )
 
             # 4. ブラウザで表示 (ファイル保存モードでない場合)
@@ -1696,38 +1729,39 @@ class Synapsen_Nexus(ctk.CTk):
         if self.current_selected_row is None:
             messagebox.showinfo("情報", "ローカルグラフを表示するノートを選択してください。")
             return
-
-        if self.df is None:
+        if self.df is None or self.db_conn is None:
             return
 
         center_key = self.current_selected_row.get('key')
         if not center_key:
             return
 
-        # 1. 関連するキーのセットを作成 (中心ノード + リンク先 + リンク元)
         related_keys = set()
         related_keys.add(center_key)
 
-        # A. このノートが引用している先 (Forward Links)
-        # memo欄から [[key]] を抽出して追加
-        memo = self.current_selected_row.get('memo', '')
-        link_pattern = re.compile(r"\[\[(.*?)\]\]")
-        for match in link_pattern.finditer(memo):
-            # [[key: title]] の形式も考慮し、:の前だけを取得
-            content = match.group(1).split(':')[0].strip()
-            related_keys.add(content)
+        try:
+            # (db_conn は読み取り専用接続)
+            cursor = self.db_conn.cursor()
 
-        # B. このノートを引用している元 (Backlinks)
-        # 全件走査で center_key を含んでいるノートを探す
-        escaped_key = re.escape(center_key)
-        # [[key]] または [[key:title]] にマッチ
-        pattern = f"\\[\\[{escaped_key}[:\\]]"
+            # A. このノートが引用している先 (Forward Links)
+            cursor.execute(
+                "SELECT target_key FROM note_links WHERE source_key = ?",
+                (center_key,)
+            )
+            for row in cursor.fetchall():
+                related_keys.add(row[0])
 
-        # 高速化のため、memo列が空でない行のみ対象にする等の工夫も可能ですが、
-        # ここではシンプルに str.contains でフィルタリングします
-        backlinks = self.df[
-            self.df['memo'].str.contains(pattern, regex=True, na=False)]
-        related_keys.update(backlinks['key'].tolist())
+            # B. このノートを引用している元 (Backlinks)
+            cursor.execute(
+                "SELECT source_key FROM note_links WHERE target_key = ?",
+                (center_key,)
+            )
+            for row in cursor.fetchall():
+                related_keys.add(row[0])
+
+        except Exception as e:
+            logger.error(f"ローカルグラフのリンク取得エラー: {e}")
+            # エラーが発生しても、中心ノードのみでグラフ生成を試みる
 
         # 2. 関連キーのみを含むDataFrameを作成
         local_df = self.df[self.df['key'].isin(related_keys)]
@@ -1828,19 +1862,38 @@ class Synapsen_Nexus(ctk.CTk):
                 return
             note_data = self.current_selected_row
 
-        if self.df is None:
+        if self.df is None or self.db_conn is None:
             messagebox.showwarning("データなし", "データベースが読み込まれていません。")
             return
+
+        key_to_edit = note_data.get("key")
+
+        # --- DBから最新の 'memo' を取得 ---
+        # NoteEditorWindowに渡す note_data (pd.Series) をコピーして更新する
+        note_data_with_memo = note_data.copy()
+        try:
+            cursor = self.db_conn.cursor()
+            cursor.execute(
+                "SELECT memo FROM notes WHERE key = ?", (key_to_edit,)
+            )
+            memo_data = cursor.fetchone()
+            if memo_data:
+                note_data_with_memo['memo'] = str(memo_data[0])
+            else:
+                note_data_with_memo['memo'] = ""  # DBにメモがない場合
+        except Exception as e:
+            logger.error(f"編集ウィンドウ用のメモ取得エラー: {e}")
+            note_data_with_memo['memo'] = ""  # 失敗時は空メモ
 
         # 編集ウィンドウ (書き込み可能) のインスタンスを作成
         editor_win = NoteEditorWindow(
             self,
-            note_data,
+            note_data_with_memo,   # 最新メモ入りのデータを渡す
             self.commonplace_keys_options,
-            self.predefined_tags,
+            self.all_unique_tags,  # 全タグを渡す
             self.save_edit_callback
         )
-        editor_win.focus()  # ウィンドウにフォーカスを当てる
+        editor_win.focus()
 
     def save_edit_callback(self, new_data_dict):
         """
@@ -1856,20 +1909,29 @@ class Synapsen_Nexus(ctk.CTk):
         if not key_to_update:
             raise Exception("更新対象のKeyが不明です。")
 
+        conn = None
         try:
-            # 1. utilsのDB更新関数を呼び出す
-            update_note_in_db(
-                self.loaded_db_path, key_to_update, new_data_dict)
+            # 1. 書き込み用のDB接続を開始
+            conn = sqlite3.connect(self.loaded_db_path)
 
-            # 2. 変更をUIに反映するため、DBを再読み込み
-            #    (load_db_from_path が self.db_conn も再生成する)
+            # 2. utilsのDB更新関数を呼び出す (connを渡す)
+            update_note_in_db(conn, key_to_update, new_data_dict)
+
+            # 3. トランザクションをコミット
+            conn.commit()
+
+            # 4. 変更をUIに反映するため、DBを再読み込み
             self.load_db_from_path(
                 self.loaded_db_path, key_to_redisplay=key_to_update)
 
         except Exception as e:
-            # (エラーハンドリングはそのまま)
+            if conn:
+                conn.rollback()
             messagebox.showerror(
                 "保存エラー", f"データベースの更新に失敗しました:\n{e}", parent=self)
+        finally:
+            if conn:
+                conn.close()
 
     def confirm_delete_note(self):
         """
@@ -1896,12 +1958,19 @@ class Synapsen_Nexus(ctk.CTk):
             parent=self
         )
 
-        if answer:  # Yesが押されたら
+        if answer:
+            conn = None
             try:
-                # 1. utilsのDB削除関数を呼び出す
-                delete_note_from_db(self.loaded_db_path, key_to_delete)
+                # 1. 書き込み用のDB接続を開始
+                conn = sqlite3.connect(self.loaded_db_path)
 
-                # 2. 変更をUIに反映するため、DBを再読み込み
+                # 2. utilsのDB削除関数を呼び出す (connを渡す)
+                delete_note_from_db(conn, key_to_delete)
+
+                # 3. トランザクションをコミット
+                conn.commit()
+
+                # 4. 変更をUIに反映するため、DBを再読み込み
                 logger.info(f"ノート {key_to_delete} を削除しました。DBを再読み込みします。")
                 self.load_db_from_path(self.loaded_db_path)
 
@@ -1909,8 +1978,13 @@ class Synapsen_Nexus(ctk.CTk):
                     "削除完了", f"ノート {key_to_delete} を削除しました。", parent=self)
 
             except Exception as e:
+                if conn:
+                    conn.rollback()
                 messagebox.showerror(
                     "削除エラー", f"データベースからの削除に失敗しました:\n{e}", parent=self)
+            finally:
+                if conn:
+                    conn.close()
 
 
 # ==============================================================================

--- a/Synapsen_Nexus/graph_manager.py
+++ b/Synapsen_Nexus/graph_manager.py
@@ -1,11 +1,11 @@
 import networkx as nx
 from pyvis.network import Network
-import re
 import sys
 import webbrowser
 from pathlib import Path
 from textwrap import dedent
 from utils import get_pdf_uri_for_note
+import sqlite3
 
 import logging
 logger = logging.getLogger(__name__)
@@ -19,7 +19,8 @@ class GraphManager:
         key_colors,
         loaded_db_path,
         pdf_root_folder,
-        output_path=None
+        output_path=None,
+        db_conn=None  # NexusからDB接続を受け取る
     ):
         """
         DataFrameからネットワークグラフを生成し、HTMLファイルとして保存する。
@@ -27,10 +28,49 @@ class GraphManager:
         Returns:
             Path: 保存されたHTMLファイルのパス。
         """
-        # 1. グラフ構築 (NetworkX)
+        # グラフ構築 (NetworkX)
         G = nx.DiGraph()
-        notes_in_graph = set(df['key'])
-        link_pattern = re.compile(r"\[\[(.*?)\]\]")
+        keys_in_graph = set(df['key'])
+
+        # グラフ化対象のリンク(edge)をDBから一括取得
+        edges_data = []
+        if (db_conn or loaded_db_path) and keys_in_graph:
+            conn_to_use = None
+            created_conn = False
+            try:
+                if db_conn:
+                    # Nexusから渡された読み取り専用接続を使用
+                    conn_to_use = db_conn
+                else:
+                    # (ExportManagerなどから呼ばれた場合) 自分で接続を作成
+                    conn_to_use = sqlite3.connect(
+                        f"file:{loaded_db_path}?mode=ro", uri=True)
+                    created_conn = True
+
+                cursor = conn_to_use.cursor()
+
+                # プレースホルダ (?) をキーの数だけ生成
+                placeholders = ','.join('?' for _ in keys_in_graph)
+
+                # リンク元(source)がグラフ対象に含まれるリンクのみ取得
+                sql = (
+                    f"SELECT source_key, target_key FROM note_links WHERE "
+                    f"source_key IN ({placeholders})"
+                )
+
+                cursor.execute(sql, tuple(keys_in_graph))
+                edges_data = cursor.fetchall()
+
+                logger.info(
+                    f"[GraphManager] DBから {len(edges_data)} 件のリンク(エッジ)を取得しました。"
+                )
+
+            except Exception as e:
+                logger.error(f"[GraphManager] DBからのリンク取得に失敗: {e}")
+            finally:
+                # 自分で作成した接続のみ閉じる
+                if created_conn and conn_to_use:
+                    conn_to_use.close()
 
         # ノードを追加
         for index, row in df.iterrows():
@@ -66,18 +106,14 @@ class GraphManager:
 
         # エッジを追加
         edge_count = 0
-        for index, row in df.iterrows():
-            source_key = row.get('key')
-            memo = row.get('memo', '')
 
-            for match in link_pattern.finditer(memo):
-                full_match_content = match.group(1).strip()
-                target_key = full_match_content.split(':')[0].strip()
-
-                if target_key in notes_in_graph:
-                    if source_key != target_key:
-                        G.add_edge(source_key, target_key)
-                        edge_count += 1
+        # DBから取得した edges_data をイテレート
+        for source_key, target_key in edges_data:
+            # リンク先(target)もグラフ描画対象(keys_in_graph)に含まれるか確認
+            if target_key in keys_in_graph:
+                if source_key != target_key:
+                    G.add_edge(source_key, target_key)
+                    edge_count += 1
 
         logger.info(f"[GraphManager] グラフ生成: {len(df)} ノード, {edge_count} エッジ")
 

--- a/Synapsen_Nexus/preview_window.py
+++ b/Synapsen_Nexus/preview_window.py
@@ -1,8 +1,9 @@
 import customtkinter as ctk
+import pandas as pd
 
 # utilsからメモ欄構築関数をインポート
 from utils import (
-    build_memo_display, find_backlinks_df, build_references_display,
+    build_memo_display, build_references_display,
     get_pdf_page_image
 )
 
@@ -243,16 +244,45 @@ class NotePreviewWindow(ctk.CTkToplevel):
         """
         current_key = self.note_data.get('key', '')
 
-        # メインアプリのDataFrameと設定を使って検索
-        backlinks_df = find_backlinks_df(
-            self.parent_app.df, current_key
-        )
+        backlinks_df = pd.DataFrame()  # 空で初期化
+        # メインアプリ (parent_app) からDB接続を取得
+        db_conn = self.parent_app.db_conn
+
+        if db_conn and current_key:
+            try:
+                # メインウィンドウの show_details と同じ LIKE 検索を実行
+                # リンクテーブルを検索
+                sql = "SELECT source_key FROM note_links WHERE target_key = ?"
+
+                cursor = db_conn.cursor()
+                cursor.execute(sql, (current_key,))
+
+                matching_keys = {row[0] for row in cursor.fetchall()}
+
+                if matching_keys:
+                    logger.debug(
+                        f"[Preview] リンクテーブル検索ヒット: {len(matching_keys)} 件 "
+                        f"(Key: {current_key})"
+                    )
+                    backlinks_df = (
+                        self.parent_app.df[
+                            self.parent_app.df['key'].isin(matching_keys)
+                        ]
+                    )
+                else:
+                    logger.debug(
+                        f"[Preview] リンクテーブル検索 0件 (Key: {current_key})"
+                    )
+
+            except Exception as e:
+                logger.error(f"[Preview] 引用元のDB検索エラー: {e}", exc_info=True)
+                pass  # 失敗時は空のまま
 
         # utilsの関数を使って引用元UIを構築
         build_references_display(
             self.references_display_frame,
             backlinks_df,
-            self.parent_app.open_preview_window,  # Callback to main app
+            self.parent_app.open_preview_window,
             self.parent_app.key_icons,
             self.parent_app.key_colors
         )

--- a/Synapsen_Nexus/utils.py
+++ b/Synapsen_Nexus/utils.py
@@ -317,38 +317,68 @@ def build_memo_display(
         label.pack(fill="x", padx=2, pady=0)
 
 
-def find_backlinks_df(df, current_key):
+def _extract_links(memo_text: str) -> set:
     """
-    DataFrame全体を検索し、指定されたkeyにリンクしている
-    ノート（引用元）のDataFrameを返す。
+    メモテキストから [[key]] または [[key:title]] 形式のリンクを抽出し、
+    key のセットを返す。
 
     Args:
-        df (pd.DataFrame): 検索対象のDataFrame。
-        current_key (str): 検索対象のノートのキー。
+        memo_text (str): 解析対象のメモテキスト。
 
     Returns:
-        pd.DataFrame: 引用元ノートを含むDataFrame。
+        set: 抽出されたユニークな 'key' のセット。
     """
-    if df is None or 'memo' not in df.columns or not current_key:
-        return pd.DataFrame()
+    if not memo_text:
+        return set()
 
-    # [[key]] または [[key:title...]] にマッチする正規表現
-    # ( \[\[ で [[ をエスケープ, r'[:\]]' で : または ] が続くものにマッチ )
-    pattern = r'\[\[' + re.escape(current_key) + r'[:\]]'
+    link_pattern = re.compile(r"\[\[(.*?)\]\]")
+    found_keys = set()
 
-    try:
-        backlink_mask = df['memo'].str.contains(
-            pattern, case=False, na=False, regex=True
+    for match in link_pattern.finditer(memo_text):
+        full_match_content = match.group(1).strip()
+        # 'key' または 'key: title' の 'key' の部分を取得
+        link_key = full_match_content.split(':')[0].strip()
+        if link_key:
+            found_keys.add(link_key)
+
+    return found_keys
+
+
+def _update_note_links(
+        cursor: sqlite3.Cursor,
+        source_key: str,
+        new_memo_text: str
+):
+    """
+    note_links テーブルを更新する。(DELETE & INSERT)
+
+    Args:
+        cursor (sqlite3.Cursor): トランザクション実行中のカーソル。
+        source_key (str): リンク元ノートのKey。
+        new_memo_text (str): 新しいメモ本文。
+    """
+    # 1. 新しいリンク先をメモから解析
+    target_keys = _extract_links(new_memo_text)
+
+    # 2. 古いリンクを削除
+    cursor.execute(
+        "DELETE FROM note_links WHERE source_key = ?",
+        (source_key,)
+    )
+
+    # 3. 新しいリンクを挿入
+    if target_keys:
+        links_data = [
+            (source_key, target_key) for target_key in target_keys
+        ]
+        sql_insert_links = (
+            "INSERT OR IGNORE INTO note_links (source_key, target_key) "
+            "VALUES (?, ?)"
         )
-        # 自分自身へのリンクは除外
-        if 'key' in df.columns:
-            self_mask = df['key'] == current_key
-            backlink_mask = backlink_mask & ~self_mask
-
-        return df[backlink_mask].sort_values(by='date', ascending=False)
-    except Exception as e:
-        logger.error(f"Backlink search error: {e}")
-        return pd.DataFrame()
+        cursor.executemany(
+            sql_insert_links,
+            links_data
+        )
 
 
 def build_references_display(
@@ -523,33 +553,35 @@ def get_pdf_uri_for_note(row_data, loaded_db_path, pdf_root_folder):
         return None
 
 
-def update_note_in_db(db_path: Path, key: str, new_data: dict):
+def update_note_in_db(
+        conn: sqlite3.Connection,
+        key: str,
+        new_data: dict
+):
     """
-    SQLiteデータベース内の指定されたノートを更新する。
+    SQLiteデータベース内の指定されたノートを更新し、リンクテーブルも更新する。
+    ★注意: この関数は呼び出し元でトランザクション(commit/rollback)を管理する必要がある。
 
     Args:
-        db_path (Path): データベースのパス。
+        conn (sqlite3.Connection): データベース接続オブジェクト。
         key (str): 更新するノートのユニークID。
         new_data (dict): 更新するデータ ('memo', 'tags', 'commonplace_key')。
 
     Raises:
         Exception: データベースの更新に失敗した場合。
     """
-    if not db_path or not db_path.is_file():
-        raise FileNotFoundError(f"データベースファイルが見つかりません: {db_path}")
-
     # タグをリストから ';' 区切りの文字列に変換
     if 'tags' in new_data and isinstance(new_data['tags'], list):
         tags_str = ";".join(sorted(new_data['tags']))
     else:
         tags_str = new_data.get('tags', '')
 
-    conn = None
+    new_memo = new_data.get('memo', '')
+
     try:
-        conn = sqlite3.connect(db_path)
         cursor = conn.cursor()
 
-        # SQL UPDATE文
+        # 1. 'notes' テーブル本体を更新
         cursor.execute(
             """
             UPDATE notes
@@ -557,53 +589,46 @@ def update_note_in_db(db_path: Path, key: str, new_data: dict):
             WHERE key = ?
             """,
             (
-                new_data.get('memo', ''),
+                new_memo,
                 tags_str,
                 new_data.get('commonplace_key', ''),
                 key
             )
         )
-        conn.commit()
+
+        # 2. 'note_links' テーブルを更新
+        _update_note_links(cursor, key, new_memo)
 
     except Exception as e:
-        if conn:
-            conn.rollback()
-        raise Exception(f"データベースの更新に失敗しました: {e}")
-    finally:
-        if conn:
-            conn.close()
+        # ロールバックは呼び出し元で行う
+        raise Exception(f"DB更新関数(update_note_in_db)でエラー: {e}")
 
 
-def delete_note_from_db(db_path: Path, key: str):
+def delete_note_from_db(conn: sqlite3.Connection, key: str):
     """
-    SQLiteデータベースから指定されたノートを削除する。
+    SQLiteデータベースから指定されたノートを削除し、関連リンクも削除する。
+    ★注意: この関数は呼び出し元でトランザクション(commit/rollback)を管理する必要がある。
 
     Args:
-        db_path (Path): データベースのパス。
+        conn (sqlite3.Connection): データベース接続オブジェクト。
         key (str): 削除するノートのユニークID。
 
     Raises:
         Exception: データベースからの削除に失敗した場合。
     """
-    if not db_path or not db_path.is_file():
-        raise FileNotFoundError(f"データベースファイルが見つかりません: {db_path}")
-
-    conn = None
     try:
-        conn = sqlite3.connect(db_path)
         cursor = conn.cursor()
 
-        # SQL DELETE文
+        # 1. 'notes' テーブルから削除 (FTSトリガーが自動でFTS側も削除)
         cursor.execute("DELETE FROM notes WHERE key = ?", (key,))
-        conn.commit()
+
+        # 2. 'note_links' から関連リンクを削除 (リンク元として、リンク先として)
+        cursor.execute("DELETE FROM note_links WHERE source_key = ?", (key,))
+        cursor.execute("DELETE FROM note_links WHERE target_key = ?", (key,))
 
     except Exception as e:
-        if conn:
-            conn.rollback()
-        raise Exception(f"データベースからの削除に失敗しました: {e}")
-    finally:
-        if conn:
-            conn.close()
+        # ロールバックは呼び出し元で行う
+        raise Exception(f"DB削除関数(delete_note_from_db)でエラー: {e}")
 
 
 def _open_original_pdf(row_data, pdf_root_folder):


### PR DESCRIPTION
# 【Abstract】
Switch the reference management system from directly retrieving references from notes to storing them in a database. This change addresses issues with reference display corruption in FTS5 and improves the overall management of note links.

参考文献管理システムを、ノートから直接参照を取得する方式からデータベースに保存する方式に変更します。
この変更により、**FTS5移行時に発生した、引用(ノートリンク)機能の破損問題が解決**され、ノートリンクの管理全体が改善されます。