### PR TITLE
【修正】FTS5への移行で export時にFulltextを取得できなくなった問題を修正

### DIFF
--- a/Synapsen_Nexus/export_manager.py
+++ b/Synapsen_Nexus/export_manager.py
@@ -1,6 +1,7 @@
 import shutil
 import datetime
 import io
+import re
 import sqlite3
 from pathlib import Path
 from pypdf import PdfReader, PdfWriter
@@ -328,8 +329,22 @@ class ExportManager:
         for _, row in df.iterrows():
             key = row.get('key')
             if key:
-                # メモリ上のdf (row.get) ではなく、DBから取得したマップを使用
                 text = full_text_map.get(key, '')
+
+                # --- ここから整形処理 ---
+                if text:
+                    # 1. 文末記号の直後に改行を挿入
+                    #    句点、疑問符などはそのまま改行 ([。？！」])
+                    #    半角の疑問符と感嘆符及びピリオドが連続している場合、最後の記号の直後のみ改行 (\.+(?!\.))
+                    text = re.sub(r'([。？！」]|\.+(?!\.))\n*', r'\1\n', text)
+
+                    # 2. 連続する空白やタブを単一スペースに置換
+                    text = re.sub(r'[ \t]+', ' ', text)
+
+                    # 3. 連続する改行を2つまでに制限
+                    text = re.sub(r'\n{3,}', '\n\n', text)
+                # --- 整形処理ここまで ---
+
                 with open(
                     text_dir / f"{key}.txt", 'w', encoding='utf-8'
                 ) as f:


### PR DESCRIPTION
# 【Abstract】
Resolve an issue where full text could not be retrieved during export after migrating to FTS5. Add formatting processing for full text to handle newlines and spaces appropriately.

FTS5移行後のエクスポート時にFullTextが取得できない問題を解決しました。
改行やスペースを適切に処理するため、全文に対する書式設定処理を追加しました。