### PR TITLE
fix: pdf_utils.pyのinportエラーが発生していた問題を修正

### DIFF
--- a/Synapsen_Nexus/canvas_window.py
+++ b/Synapsen_Nexus/canvas_window.py
@@ -20,7 +20,7 @@ import fitz  # PyMuPDF
 # --- プロジェクト内モジュールのパス設定 ---
 current_dir = Path(__file__).parent
 root_dir = current_dir.parent
-normalisierer_dir = root_dir / "Synapsen_Nexus"
+normalisierer_dir = root_dir / "Synapsen_Normalisierer"
 
 if str(root_dir) not in sys.path:
     sys.path.append(str(root_dir))


### PR DESCRIPTION
766d9cd45149ceba620159096ffc4f85aea406f8 で行ったログの名前の変更で、Normalisiererのコードが存在しているディレクトリを指定していたコードまで変更してしまっていたのが原因だった