### PR TITLE
【仕様変更】[Normalisierer]正規化時に``DPDocType:notebook``も付与する仕様に変更

### DIFF
--- a/Synapsen_Normalisierer/pdf_utils.py
+++ b/Synapsen_Normalisierer/pdf_utils.py
@@ -219,7 +219,7 @@ def add_metadata_to_clip(
         keywords_list = [k.strip() for k in keywords.split(";") if k.strip()]
 
         # 基本フラグ
-        skip_flag = "Synapsen:SkipNormalization"
+        skip_flag = "DPDocType:notebook; Synapsen:SkipNormalization"
         if skip_flag not in keywords_list:
             keywords_list.append(skip_flag)
 


### PR DESCRIPTION
- 統合前のノートは編集可能のノートとして扱いたいため、クアデルノでのページ追加もできるように``DPDocType:notebook``を付与するように変更した
  - Fixes #110