### PR TITLE
【修正】140以上の文字がSummary欄に入る事がある問題を修正

### DIFF
--- a/Synapsen_Ersteller/pdf_processor.py
+++ b/Synapsen_Ersteller/pdf_processor.py
@@ -172,7 +172,7 @@ def get_note_info(pdf_path: Path, key_rect: tuple):
                         # 引用 (Refs) -> メモ欄へ
                         if "refs" in meta_data and isinstance(meta_data["refs"], list):
                             links = [f"[[{r}]]" for r in meta_data["refs"]]
-                            if links:
+                            if links and "Synapsen:Whiteboard" not in keywords:
                                 memo_from_refs = "\n".join(links) + "\n"
 
                         # コメント -> 140文字以内ならSummary欄、超える場合はメモ欄へ

--- a/Synapsen_Ersteller/pdf_processor.py
+++ b/Synapsen_Ersteller/pdf_processor.py
@@ -175,9 +175,18 @@ def get_note_info(pdf_path: Path, key_rect: tuple):
                             if links:
                                 memo_from_refs = "\n".join(links) + "\n"
 
-                        # コメント -> Summary欄へ
+                        # コメント -> 140文字以内ならSummary欄、超える場合はメモ欄へ
                         if "comment" in meta_data and meta_data["comment"]:
-                            summary_content = meta_data["comment"]
+                            comment_text = meta_data["comment"]
+                            if len(comment_text) > 140:
+                                # 既存の引用リンク等がある場合の改行制御
+                                if memo_from_refs and not memo_from_refs.endswith("\n"):
+                                    memo_from_refs += "\n \n"
+
+                                # 区切り文字 [Comment] を付与して追記
+                                memo_from_refs += f"\n[Comment]\n{comment_text}\n"
+                            else:
+                                summary_content = comment_text
 
                         data_found_priority = True
                         logger.info(


### PR DESCRIPTION
- Fixes #124

# 【原因】
- 正規化時に追加する最終ページ(書誌情報ページ)に埋め込むコメント(add_metadata_to_clipの引数comment_to_embed)が、summary欄にも埋め込まれる仕様が原因で発生

# 【修正法】
- 個別ファイルの正規化時に、要約をここに入れる想定での仕様であった為、comment_to_embedをmeta_info["comment"]に入れる仕様は変更しなかった
- Erstellerのget_note_info側で、文字数をトリガーとして分岐する仕様にするした
  - 140字以内 :
    - summary欄に追加
  - 140字以上
    - メモ欄に追加

## 【特殊調整】
- Canvasでは``[使用ノート一覧]``を``comment_to_embed``に投げて、文章化している
- 引用用のメモと[使用ノート一覧]は、全く同じキーを指定する為、文章が二重になる
- ``keywords``に"Synapsen:Whiteboard"が含まれているかを確認し、含まれているならば引用のメモ欄追加はスキップするようにした
  - ``[使用ノート一覧]``を残す形にした