### PR TITLE
【バグ】タグのエイリアスが残っている問題を修正

### DIFF
--- a/Synapsen_Ersteller/Synapsen_Ersteller_main.py
+++ b/Synapsen_Ersteller/Synapsen_Ersteller_main.py
@@ -1,6 +1,7 @@
 # === 1. 標準ライブラリ ===
 import os
 import sys
+import re
 from pathlib import Path
 import tkinter
 import csv
@@ -474,11 +475,17 @@ class Synapsen_Ersteller(ctk.CTk):
             tag_file = Path(self.tags_data_path)
             if tag_file.is_file():
                 with open(tag_file, "r", encoding="utf-8") as f:
-                    self.predefined_tags = [
-                        line.strip()
-                        for line in f
-                        if line.strip() and not line.startswith("#")
-                    ]
+                    tags_list = []
+                    for line in f:
+                        stripped_line = line.strip()
+                        # 空行やコメント行でないかチェック
+                        if not stripped_line or stripped_line.startswith("#"):
+                            continue
+                        # エイリアス部の削除
+                        s = r"\s*\[.*?\]\s*$"
+                        tag_name = re.sub(s, "", stripped_line).strip()
+                        tags_list.append(tag_name)
+                    self.predefined_tags = sorted(tags_list)
                 logger.info(
                     f"{len(self.predefined_tags)}件の事前定義タグを読み込みました。"
                 )

--- a/Synapsen_Nexus/utils.py
+++ b/Synapsen_Nexus/utils.py
@@ -181,10 +181,12 @@ def load_app_config(base_path):
                         for line in f:
                             stripped_line = line.strip()
                             # 空行やコメント行でないかチェック
-                            if stripped_line and not stripped_line.startswith(
-                                "#"
-                            ):  # noqa: E501
-                                tags_list.append(stripped_line)
+                            if not stripped_line or stripped_line.startswith("#"):
+                                continue
+                            # エイリアス部の削除
+                            s = r"\s*\[.*?\]\s*$"
+                            tag_name = re.sub(s, "", stripped_line).strip()
+                            tags_list.append(tag_name)
                         config_data["predefined_tags"] = sorted(tags_list)
             except Exception as e:
                 logger.error(f"tags.txtの読み込み中にエラー: {e}")


### PR DESCRIPTION
- Fixes #127
  - エイリアスを取り除く処理がNormalisiererにしか存在しなかった為、ErstellerとNexusの「既存タグ選択」ではエイリアス部分が残ったままになってしまっていた問題を修正。